### PR TITLE
Add Gateway Reference with Keycloak PEP and Tenant Enforcement

### DIFF
--- a/gateway-reference/pom.xml
+++ b/gateway-reference/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>gateway-reference</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>gateway-reference</name>
+    <description>Spring Cloud Gateway Reference with Keycloak PEP</description>
+    <properties>
+        <java.version>17</java.version>
+        <spring-cloud.version>2023.0.2</spring-cloud.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/gateway-reference/src/main/java/com/example/gateway/GatewayApplication.java
+++ b/gateway-reference/src/main/java/com/example/gateway/GatewayApplication.java
@@ -1,0 +1,13 @@
+package com.example.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayApplication.class, args);
+    }
+
+}

--- a/gateway-reference/src/main/java/com/example/gateway/config/PolicyEnforcerConfig.java
+++ b/gateway-reference/src/main/java/com/example/gateway/config/PolicyEnforcerConfig.java
@@ -1,0 +1,40 @@
+package com.example.gateway.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@ConfigurationProperties(prefix = "keycloak.policy-enforcer")
+public class PolicyEnforcerConfig {
+
+    private String authServerUrl;
+    private String realm;
+    private Map<String, String> paths = new HashMap<>();
+
+    public String getAuthServerUrl() {
+        return authServerUrl;
+    }
+
+    public void setAuthServerUrl(String authServerUrl) {
+        this.authServerUrl = authServerUrl;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    public Map<String, String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(Map<String, String> paths) {
+        this.paths = paths;
+    }
+}

--- a/gateway-reference/src/main/java/com/example/gateway/config/SecurityConfig.java
+++ b/gateway-reference/src/main/java/com/example/gateway/config/SecurityConfig.java
@@ -1,0 +1,85 @@
+package com.example.gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
+import com.example.gateway.security.KeycloakPolicyEnforcementManager;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http, KeycloakPolicyEnforcementManager policyEnforcementManager) {
+        http
+            .csrf(ServerHttpSecurity.CsrfSpec::disable)
+            .authorizeExchange(exchanges -> exchanges
+                // Health endpoints
+                .pathMatchers("/actuator/**").permitAll()
+                // Apply Keycloak Policy Enforcement
+                .anyExchange().access(policyEnforcementManager)
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
+            );
+
+        return http.build();
+    }
+
+    @Bean
+    public Converter<Jwt, Mono<AbstractAuthenticationToken>> jwtAuthenticationConverter() {
+        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(new TenantRoleConverter());
+        return new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter);
+    }
+
+    /**
+     * Extracts roles from 'active_tenant.roles' and 'realm_access.roles'
+     */
+    static class TenantRoleConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+        @Override
+        public Collection<GrantedAuthority> convert(Jwt jwt) {
+            Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+            // 1. Realm Roles
+            Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+            authorities.addAll(extractRoles(realmAccess, "ROLE_REALM_"));
+
+            // 2. Active Tenant Roles
+            Map<String, Object> activeTenant = jwt.getClaim("active_tenant");
+            authorities.addAll(extractRoles(activeTenant, "ROLE_TENANT_"));
+
+            return authorities;
+        }
+
+        @SuppressWarnings("unchecked")
+        private Collection<GrantedAuthority> extractRoles(Map<String, Object> source, String prefix) {
+            if (source == null || !source.containsKey("roles")) {
+                return Collections.emptyList();
+            }
+            Object rolesObj = source.get("roles");
+            if (rolesObj instanceof Collection<?>) {
+                return ((Collection<String>) rolesObj).stream()
+                        .map(role -> new SimpleGrantedAuthority(prefix + role.toUpperCase()))
+                        .collect(Collectors.toList());
+            }
+            return Collections.emptyList();
+        }
+    }
+}

--- a/gateway-reference/src/main/java/com/example/gateway/filter/TenantContextWebFilter.java
+++ b/gateway-reference/src/main/java/com/example/gateway/filter/TenantContextWebFilter.java
@@ -1,0 +1,120 @@
+package com.example.gateway.filter;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class TenantContextWebFilter implements GlobalFilter, Ordered {
+
+    private static final String X_TENANT_ID = "X-Tenant-Id";
+    private static final String X_USER_ID = "X-User-Id";
+    private static final String X_TENANT_ROLES = "X-Tenant-Roles";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        return ReactiveSecurityContextHolder.getContext()
+                .map(SecurityContext::getAuthentication)
+                .filter(auth -> auth instanceof JwtAuthenticationToken)
+                .map(auth -> (JwtAuthenticationToken) auth)
+                .map(jwtToken -> {
+                    Map<String, Object> claims = jwtToken.getTokenAttributes();
+
+                    // The claim is "active_tenant" which is a Map
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> activeTenant = (Map<String, Object>) claims.get("active_tenant");
+
+                    if (activeTenant == null || !activeTenant.containsKey("tenant_id")) {
+                        throw new TenantEnforcementException(HttpStatus.FORBIDDEN, "Missing tenant context in token");
+                    }
+
+                    String tokenTenantId = (String) activeTenant.get("tenant_id");
+                    String tenantHint = resolveTenantHint(exchange);
+
+                    if (tenantHint != null && !tenantHint.equals(tokenTenantId)) {
+                        throw new TenantEnforcementException(HttpStatus.FORBIDDEN, "Tenant mismatch: Hint " + tenantHint + " != Token " + tokenTenantId);
+                    }
+
+                    // Prepare trusted headers
+                    String userId = jwtToken.getName(); // 'sub' claim usually
+                    List<String> roles = extractRoles(activeTenant);
+                    String rolesStr = String.join(",", roles);
+
+                    return exchange.mutate()
+                            .request(r -> r.headers(headers -> {
+                                // Strip inbound sensitive headers
+                                headers.remove(X_TENANT_ID);
+                                headers.remove(X_USER_ID);
+                                headers.remove(X_TENANT_ROLES);
+
+                                // Inject trusted headers
+                                headers.set(X_TENANT_ID, tokenTenantId);
+                                headers.set(X_USER_ID, userId);
+                                headers.set(X_TENANT_ROLES, rolesStr);
+                            }))
+                            .build();
+                })
+                .defaultIfEmpty(exchange)
+                .flatMap(chain::filter)
+                .onErrorResume(TenantEnforcementException.class, e -> {
+                    exchange.getResponse().setStatusCode(e.getStatus());
+                    return exchange.getResponse().setComplete();
+                });
+    }
+
+    private String resolveTenantHint(ServerWebExchange exchange) {
+        // 1. Header
+        String header = exchange.getRequest().getHeaders().getFirst(X_TENANT_ID);
+        if (header != null) return header;
+
+        // 2. Path: /api/{tenant}/...
+        String path = exchange.getRequest().getURI().getPath();
+        if (path.startsWith("/api/")) {
+             String[] parts = path.split("/");
+             // parts: ["", "api", "tenant-id", "resource"...]
+             if (parts.length > 2) {
+                 return parts[2];
+             }
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractRoles(Map<String, Object> activeTenant) {
+        if (activeTenant.containsKey("roles")) {
+            Object rolesObj = activeTenant.get("roles");
+            if (rolesObj instanceof List) {
+                return (List<String>) rolesObj;
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int getOrder() {
+        return 10; // Run after Security (Authentication)
+    }
+
+    static class TenantEnforcementException extends RuntimeException {
+        private final HttpStatus status;
+
+        public TenantEnforcementException(HttpStatus status, String message) {
+            super(message);
+            this.status = status;
+        }
+
+        public HttpStatus getStatus() { return status; }
+    }
+}

--- a/gateway-reference/src/main/java/com/example/gateway/security/KeycloakPolicyEnforcementManager.java
+++ b/gateway-reference/src/main/java/com/example/gateway/security/KeycloakPolicyEnforcementManager.java
@@ -1,0 +1,91 @@
+package com.example.gateway.security;
+
+import com.example.gateway.config.PolicyEnforcerConfig;
+import org.springframework.http.MediaType;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.ReactiveAuthorizationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Component
+public class KeycloakPolicyEnforcementManager implements ReactiveAuthorizationManager<AuthorizationContext> {
+
+    private final WebClient webClient;
+    private final PolicyEnforcerConfig config;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public KeycloakPolicyEnforcementManager(WebClient.Builder webClientBuilder, PolicyEnforcerConfig config) {
+        this.webClient = webClientBuilder.build();
+        this.config = config;
+    }
+
+    @Override
+    public Mono<AuthorizationDecision> check(Mono<Authentication> authentication, AuthorizationContext context) {
+        return authentication
+                .filter(a -> a instanceof JwtAuthenticationToken)
+                .flatMap(auth -> {
+                    JwtAuthenticationToken jwtAuth = (JwtAuthenticationToken) auth;
+                    String token = jwtAuth.getToken().getTokenValue();
+                    String path = context.getExchange().getRequest().getURI().getPath();
+
+                    String resource = resolveResource(path);
+
+                    if (resource == null) {
+                        // For paths not mapped to a Keycloak resource, we default to granting access
+                        // (relying on standard authentication).
+                        // Adjust logic here if "Deny by default" is required for unmapped resources.
+                        return Mono.just(new AuthorizationDecision(true));
+                    }
+
+                    return checkPermissions(token, resource);
+                })
+                .defaultIfEmpty(new AuthorizationDecision(false));
+    }
+
+    private String resolveResource(String path) {
+        if (config.getPaths() == null) return null;
+
+        // Find best match.
+        // Note: Simple iteration. Specificity logic (longest match) might be needed for complex cases.
+        for (Map.Entry<String, String> entry : config.getPaths().entrySet()) {
+            if (pathMatcher.match(entry.getKey(), path)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private Mono<AuthorizationDecision> checkPermissions(String accessToken, String resource) {
+        String url = String.format("%s/realms/%s/protocol/openid-connect/token",
+                config.getAuthServerUrl(), config.getRealm());
+
+        // Call Keycloak Authorization Endpoint
+        return webClient.post()
+                .uri(url)
+                .headers(h -> h.setBearerAuth(accessToken))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket")
+                        .with("permission", resource))
+                .retrieve()
+                .toBodilessEntity()
+                .map(response -> new AuthorizationDecision(response.getStatusCode().is2xxSuccessful()))
+                .onErrorResume(WebClientResponseException.class, e -> {
+                    // 403 means Policy Denied
+                    if (e.getStatusCode().value() == 403) {
+                        return Mono.just(new AuthorizationDecision(false));
+                    }
+                    // Other errors (401, 500) -> Deny and log?
+                    return Mono.just(new AuthorizationDecision(false));
+                })
+                .onErrorReturn(new AuthorizationDecision(false));
+    }
+}

--- a/gateway-reference/src/main/resources/application.yml
+++ b/gateway-reference/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: api-gateway
+  cloud:
+    gateway:
+      routes:
+        - id: tenant-service
+          uri: http://localhost:8081
+          predicates:
+            - Path=/api/**
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/azguards-whatsapp}
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://localhost:8080/realms/azguards-whatsapp/protocol/openid-connect/certs}
+
+keycloak:
+  policy-enforcer:
+    auth-server-url: ${KEYCLOAK_AUTH_SERVER_URL:http://localhost:8080}
+    realm: ${KEYCLOAK_REALM:azguards-whatsapp}
+    paths:
+      "/api/admin/**": "admin-resource"
+      "/api/reports/**": "reports-resource"

--- a/gateway-reference/src/test/java/com/example/gateway/filter/TenantContextWebFilterTest.java
+++ b/gateway-reference/src/test/java/com/example/gateway/filter/TenantContextWebFilterTest.java
@@ -1,0 +1,83 @@
+package com.example.gateway.filter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+class TenantContextWebFilterTest {
+
+    private final TenantContextWebFilter filter = new TenantContextWebFilter();
+    private final GatewayFilterChain chain = mock(GatewayFilterChain.class);
+
+    @Test
+    void shouldAllowWhenTenantMatches() {
+        when(chain.filter(any())).thenReturn(Mono.empty());
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/tenant-1/resource")
+                .header("X-Tenant-Id", "tenant-1")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        Jwt jwt = createJwt("tenant-1");
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+
+        filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(new SecurityContextImpl(auth))))
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+        verify(chain).filter(argThat(ex -> {
+             return "tenant-1".equals(ex.getRequest().getHeaders().getFirst("X-Tenant-Id"));
+        }));
+    }
+
+    @Test
+    void shouldRejectWhenTenantMismatch() {
+        when(chain.filter(any())).thenReturn(Mono.empty());
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/tenant-1/resource")
+                .header("X-Tenant-Id", "tenant-2") // Mismatch
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        Jwt jwt = createJwt("tenant-1");
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+
+        filter.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(new SecurityContextImpl(auth))))
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+        assert exchange.getResponse().getStatusCode() == HttpStatus.FORBIDDEN;
+    }
+
+    private Jwt createJwt(String tenantId) {
+        Map<String, Object> claims = new HashMap<>();
+        Map<String, Object> activeTenant = new HashMap<>();
+        activeTenant.put("tenant_id", tenantId);
+        activeTenant.put("roles", Collections.singletonList("ADMIN"));
+        claims.put("active_tenant", activeTenant);
+        claims.put("sub", "user-123");
+
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claims(c -> c.putAll(claims))
+                .build();
+    }
+}

--- a/gateway-reference/src/test/java/com/example/gateway/security/KeycloakPolicyEnforcementManagerTest.java
+++ b/gateway-reference/src/test/java/com/example/gateway/security/KeycloakPolicyEnforcementManagerTest.java
@@ -1,0 +1,85 @@
+package com.example.gateway.security;
+
+import com.example.gateway.config.PolicyEnforcerConfig;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class KeycloakPolicyEnforcementManagerTest {
+
+    private MockWebServer mockWebServer;
+    private KeycloakPolicyEnforcementManager manager;
+
+    @BeforeEach
+    void setup() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        PolicyEnforcerConfig config = new PolicyEnforcerConfig();
+        // The manager appends /realms/... so we just give the base url.
+        // Note: The manager implementation: String.format("%s/realms/%s/...", config.getAuthServerUrl(), config.getRealm());
+        // So I'll just set the root of mockserver as authServerUrl.
+        config.setAuthServerUrl(mockWebServer.url("").toString().replaceAll("/$", "")); // strip trailing slash
+        config.setRealm("test-realm");
+        config.setPaths(Collections.singletonMap("/api/**", "api-resource"));
+
+        manager = new KeycloakPolicyEnforcementManager(WebClient.builder(), config);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void shouldGrantAccessWhenKeycloakApproves() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\"rpt\": \"token\"}"));
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/test").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AuthorizationContext context = new AuthorizationContext(exchange);
+
+        Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").claim("sub", "user").build();
+        Authentication auth = new JwtAuthenticationToken(jwt);
+
+        manager.check(Mono.just(auth), context)
+                .as(StepVerifier::create)
+                .expectNextMatches(decision -> decision.isGranted())
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldDenyAccessWhenKeycloakForbids() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(403));
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/test").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AuthorizationContext context = new AuthorizationContext(exchange);
+
+        Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").claim("sub", "user").build();
+        Authentication auth = new JwtAuthenticationToken(jwt);
+
+        manager.check(Mono.just(auth), context)
+                .as(StepVerifier::create)
+                .expectNextMatches(decision -> !decision.isGranted())
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
This PR introduces a reference implementation for a Spring Cloud Gateway acting as a Policy Enforcement Point (PEP) in a Keycloak multi-tenant environment.

Key features:
1.  **Remote Policy Enforcement**: `KeycloakPolicyEnforcementManager` intercepts requests and queries Keycloak's Authorization Endpoint (`grant_type=uma-ticket`) to verify permissions for the requested resource (mapped from path).
2.  **Strict Tenant Enforcement**: `TenantContextWebFilter` (Global Filter) ensures that the tenant ID in the JWT (`active_tenant`) matches any tenant hint provided in the request (Path `/api/{tenantId}`, Header `X-Tenant-Id`). It rejects mismatches with 403 Forbidden.
3.  **Secure Header Injection**: Inbound sensitive headers are stripped, and trusted headers (`X-Tenant-Id`, `X-User-Id`, `X-Tenant-Roles`) are injected for downstream services.
4.  **Reactive Stack**: Fully non-blocking implementation using Spring WebFlux and Reactor.

Configuration defaults to `localhost:8080` and realm `azguards-whatsapp` but is externalized.


---
*PR created automatically by Jules for task [17828089384096798553](https://jules.google.com/task/17828089384096798553) started by @AsifBh*